### PR TITLE
Fixed typographical error, changed accomodate to accommodate in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Well maybe that felt a little weird or you aren't using WebAPI or MVC. No proble
 ```
 
 ##Putting it all together
-Here is the bread and butter of FluentKnockoutHelpers. Since we have created a strongly-typed helper we now can use it to create strongly-typed expressions that at run time yield plain old Knockout code sans the magic strings. Since everyone likes to do their HTML in many different ways FluentKnockoutHelpers is flexible and extensible to accomodate many different ways of accomplishing the same markup result.
+Here is the bread and butter of FluentKnockoutHelpers. Since we have created a strongly-typed helper we now can use it to create strongly-typed expressions that at run time yield plain old Knockout code sans the magic strings. Since everyone likes to do their HTML in many different ways FluentKnockoutHelpers is flexible and extensible to accommodate many different ways of accomplishing the same markup result.
 ###The markup we want to generate
 ```html
     <div class="control-group">


### PR DESCRIPTION
@johnculviner, I've corrected a typographical error in the documentation of the [FluentKnockoutHelpers](https://github.com/johnculviner/FluentKnockoutHelpers) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
